### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ Each subdirectory carries its own `readme.md` with parameters and post-deploymen
 
 ## Repository layout
 - `CloudFormation/` — AWS CloudFormation templates (basic and advanced single-instance configurations).
-- `Terraform/` — Terraform configurations (e.g. `Cloud-to-Cloud/`).
-- `TerraformCloud/` — Terraform Cloud + vSphere + Ansible reference deployment.
+- `Terraform/` — Terraform configurations for AWS, Azure, and Cloud-to-Cloud connectivity.
+- `TerraformCloud/` — Terraform Cloud + Ansible reference deployments for AWS, Azure, Google Cloud, and vSphere.
 - `README.md` — placeholder.
 
 ## Cross-repo context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ Each subdirectory carries its own `readme.md` with parameters and post-deploymen
 
 ## Repository layout
 - `CloudFormation/` — AWS CloudFormation templates (basic and advanced single-instance configurations).
-- `Terraform/` — Terraform configurations for AWS, Azure, and Cloud-to-Cloud connectivity.
-- `TerraformCloud/` — Terraform Cloud + Ansible reference deployments for AWS, Azure, Google Cloud, and vSphere.
+- `Terraform/` — Terraform configurations (e.g. `Cloud-to-Cloud/`).
+- `TerraformCloud/` — Terraform Cloud + vSphere + Ansible reference deployment.
 - `README.md` — placeholder.
 
 ## Cross-repo context
@@ -37,7 +37,3 @@ Mirror twin: `VyOS-Networks/vyos-automation`. Mirror pipeline not confirmed live
 - Each template ships with example post-deployment VyOS config text files. Keep these in sync when interface naming or default-config conventions change in `vyos-1x`.
 - No CI runs Terraform validation — when adding HCL, run `terraform fmt -recursive` and `terraform validate` locally before pushing.
 - Public-facing repo: don't embed AWS account IDs, real customer keys, or non-RFC-5737 IPv4 / non-RFC-3849 IPv6 ranges in examples.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-automation`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818020627). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+## Project purpose
+Sample cloud-deployment templates for VyOS instances. Provides ready-to-use AWS CloudFormation stacks and Terraform/Terraform Cloud configurations for deploying VyOS routers in AWS and vSphere environments.
+
+## Tech stack
+- HashiCorp HCL (Terraform) + AWS CloudFormation YAML.
+- No build system — assets are consumed directly by `terraform`/`aws cloudformation` clients.
+
+## Build / test / run
+No build. Usage examples:
+```
+# CloudFormation
+aws cloudformation deploy --template-file CloudFormation/<flavor>/<file>.yml --stack-name <name>
+# Terraform
+cd Terraform/<scenario> && terraform init && terraform apply
+```
+Each subdirectory carries its own `readme.md` with parameters and post-deployment config.
+
+## Repository layout
+- `CloudFormation/` — AWS CloudFormation templates (basic and advanced single-instance configurations).
+- `Terraform/` — Terraform configurations (e.g. `Cloud-to-Cloud/`).
+- `TerraformCloud/` — Terraform Cloud + vSphere + Ansible reference deployment.
+- `README.md` — placeholder.
+
+## Cross-repo context
+End-user-facing documentation samples. Independent of the build pipeline (`vyos-build`, `vyos-1x`, etc.) — these templates consume already-built VyOS images (typically from cloud marketplaces or the nightly/release artifacts published by `vyos/vyos-nightly-build`). Companion to `vyos/vyos-documentation` for cloud-deployment guidance.
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev) — enforced by inherited `vyos/.github` reusable workflows where applicable.
+- Only workflow currently present: `cla-check.yml` (CLA gate via `vyos/vyos-cla-signatures`).
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-automation`. Mirror pipeline not confirmed live; canonical edits happen on the `vyos/*` side.
+
+## Notes for future contributors
+- Each template ships with example post-deployment VyOS config text files. Keep these in sync when interface naming or default-config conventions change in `vyos-1x`.
+- No CI runs Terraform validation — when adding HCL, run `terraform fmt -recursive` and `terraform validate` locally before pushing.
+- Public-facing repo: don't embed AWS account IDs, real customer keys, or non-RFC-5737 IPv4 / non-RFC-3849 IPv6 ranges in examples.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-automation`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818020627). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 ## Project purpose
-Sample cloud-deployment templates for VyOS instances. Provides ready-to-use AWS CloudFormation stacks and Terraform/Terraform Cloud configurations for deploying VyOS routers in AWS and vSphere environments.
+Sample cloud-deployment templates for VyOS instances. Provides ready-to-use AWS CloudFormation stacks and Terraform/Terraform Cloud configurations for deploying VyOS routers in AWS, Azure, Google Cloud, and vSphere environments.
 
 ## Tech stack
 - HashiCorp HCL (Terraform) + AWS CloudFormation YAML.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
