### PR TITLE
T8615: add Mergify config (extends: mergify central template)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://docs.mergify.com/configuration/file-format/
+extends: mergify
+merge_protections_settings:
+  reporting_method: check-runs

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://docs.mergify.com/configuration/file-format/
+# yaml-language-server: $schema=https://docs.mergify.com/mergify-configuration-schema.json
 extends: mergify
 merge_protections_settings:
   reporting_method: check-runs


### PR DESCRIPTION
## What

Adds the central-config Mergify inheritance file per the [T8615](https://vyos.dev/T8615) sweep (re-scoped 2026-05-28). Minimum 4-line template:

```yaml
# yaml-language-server: $schema=https://docs.mergify.com/configuration/file-format/
extends: mergify
merge_protections_settings:
  reporting_method: check-runs
```

## Why

`extends: mergify` resolves to `vyos/mergify` (per-org central), inheriting:
- `commands_restrictions` on all 9 currently-documented Mergify slash commands, restricted to `@vyos/maintainers`, `@VyOS-Networks/maintainers`, `vyosbot`, and `vyos-bot[bot]` (the App identity from Mirror Pipeline Rollout 1).
- Conflict labeler (`conflicts` label on PRs in merge conflict with base).
- PR-title T-ID format check (`invalid-title` label on PRs whose title does not match `T<digits>: <text>`).
- Opt-in auto-update via the `auto-update` label.
- Backport-conflict merge protection (`backport-conflict` label blocks merge).

`merge_protections_settings: reporting_method: check-runs` declared explicitly per-repo because only `defaults` and `commands_restrictions` are documented as merging across `extends:` — pin to current behavior pre the 2026-07-31 default flip per `data/github.md` Mergify gotchas table.

## Test plan

- [x] Phase 0 local CR (see commit message; central-provided rules account for the known false positive about `extends: mergify` not being a recognized preset — Mergify documents the org-local form at https://docs.mergify.com/configuration/sharing/).
- [ ] Post-flip GitHub-side CR review.
- [ ] Mergify Configuration changed check passes on the new file.

Refs: [T8615](https://vyos.dev/T8615) (re-scoped 2026-05-28), [IS-421](https://vyos.atlassian.net/browse/IS-421).

🤖 Generated by [robots](https://vyos.io)


[IS-421]: https://vyos.atlassian.net/browse/IS-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ