### PR TITLE
github: T9045: fix dead workflows dir name and stale CLA reusable ref

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -14,5 +14,5 @@ on:
 
 jobs:
   call-cla-assistant:
-    uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current
+    uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@production
     secrets: inherit


### PR DESCRIPTION
## Problem

The GitHub Actions directory in this repo is literally named `.github/workflows  ` — with **two trailing spaces**. GitHub only executes workflows from the exact path `.github/workflows/`, so every workflow in this repo is dead and has never run — including the CLA check, the directory's only workflow. External-contributor PRs have merged with no CLA enforcement.

The dead file also pins the CLA reusable at `vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current` — a stale ref from before the branch rename. The misnamed directory hid this file from the earlier fleet-wide `@current` ref sweep.

## Fix

1. `git mv '.github/workflows  ' .github/workflows` — revives the directory.
2. Repoint the `uses:` ref from `@current` to `@production`, matching the other 28 vyos-org CLA callers.

Reviving the directory activates only the CLA check — `cla-check.yml` is verified to be the sole file in it (no schedulers, no mirror callers).

Note: the CLA check will not run on this PR itself — `pull_request_target` reads workflows from the base branch, where the directory is still misnamed. It becomes active for subsequent PRs after merge.

## Pre-PR review disposition

Local CodeRabbit review (Phase 0) flagged the mutable `@production` ref + `secrets: inherit` under `pull_request_target`, suggesting an immutable commit-SHA pin and narrowed secrets. Deliberately not applied: all 56 CLA callers across both orgs pin `@production` with `secrets: inherit` (this file becomes the 57th identical copy), and an in-flight change to the reusable on its `production` branch relies on callers tracking the branch — a SHA-pinned caller would silently keep the retired credential path. Moving the fleet to SHA-pinned reusables is a separate, fleet-wide decision.

Resolves: T9045

🤖 Generated by [robots](https://vyos.io)